### PR TITLE
PHP7.4のnull等への添字アクセスで警告が出るようになったので対応

### DIFF
--- a/src/QdsmtpBase.php
+++ b/src/QdsmtpBase.php
@@ -43,6 +43,9 @@ class QdsmtpBase extends QdsmtpError
 	var $always_notify_success = false;
 
 	function __construct( $param = null ){
+        if (is_null($param)) {
+            return;
+        }
 		if( !is_null( $param[0] ) && is_bool( $param[0] ) ){
 			$this->continue = $continue;
 		}

--- a/src/QdsmtpBase.php
+++ b/src/QdsmtpBase.php
@@ -43,9 +43,9 @@ class QdsmtpBase extends QdsmtpError
 	var $always_notify_success = false;
 
 	function __construct( $param = null ){
-        if (is_null($param)) {
-            return;
-        }
+		if (is_null($param)) {
+			return;
+		}
 		if( !is_null( $param[0] ) && is_bool( $param[0] ) ){
 			$this->continue = $continue;
 		}


### PR DESCRIPTION
PHP7.4の下位互換性のない変更点の以下への対応です。
ご確認お願いいたします。

> 配列でない値を配列スタイルでアクセスした場合[ ¶](https://www.php.net/manual/ja/migration74.incompatible.php#migration74.incompatible.core.non-array-access)
[null](https://www.php.net/manual/ja/language.types.null.php), [bool](https://www.php.net/manual/ja/language.types.boolean.php), [int](https://www.php.net/manual/ja/language.types.integer.php), [float](https://www.php.net/manual/ja/language.types.float.php) または [resource](https://www.php.net/manual/ja/language.types.resource.php) 型を ($null["key"] のように) 配列としてアクセスしようとすると、警告が生成されるようになりました。

https://www.php.net/manual/ja/migration74.incompatible.php#migration74.incompatible.core.non-array-access